### PR TITLE
Need to require securerandom

### DIFF
--- a/lib/fatsecret.rb
+++ b/lib/fatsecret.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'openssl'
 require 'cgi'
 require 'base64'
+require 'securerandom'
 
 class String 
 	  def esc 


### PR DESCRIPTION
Hey @whistler, turns out I was using securerandom outside of the gem for something else, forgot to make sure you require it as well. The released gem is broken until you push this out. Sorry!
